### PR TITLE
Fix for distortions when loading settings

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -41,6 +41,14 @@ void ofApp::setup()
 		warp->setSize(this->texture.getWidth(), this->texture.getHeight());
 		warp->setEdges(glm::vec4(0.0f, 1.0f, 1.0f, 0.0f));
 	}
+	else
+	{
+		for (auto i = 0; i < this->warpController.getNumWarps(); ++i)
+		{
+			auto warp = this->warpController.getWarp(i);
+			warp->setSize(this->texture.getWidth(), this->texture.getHeight());
+		}
+	}
 
 	this->srcAreas.resize(this->warpController.getNumWarps());
 


### PR DESCRIPTION
This is a fix for the issues noted in #5.

This might be more of a workaround and a real fix might be storing the width and height in the json.